### PR TITLE
Support Operation Name in Requests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "typescript.tsserver.experimental.enableProjectDiagnostics": true,
+  "editor.formatOnSave": true,
+  "xo.enable": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "prettier.prettierPath": "./node_modules/prettier",
+  "tailwindCSS.experimental.classRegex": [
+    "tw`([^`]*)",
+    "tw\\.style\\(([^)]*)\\)"
+  ],
+  "tailwindCSS.includeLanguages": {
+    "tsx": "jsx"
+  }
+}

--- a/.xo-config.json
+++ b/.xo-config.json
@@ -3,10 +3,6 @@
   "space": true,
   "nodeVersion": false,
   "rules": {
-    "@typescript-eslint/array-type": [
-      "error",
-      { "default": "array", "readonly": "array" }
-    ],
     "@typescript-eslint/naming-convention": "off",
     "@typescript-eslint/no-floating-promises": "off",
     "@typescript-eslint/parameter-properties": [

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
   - [Create a Mongo Client](#create-a-mongo-client)
   - [Select a Database](#select-a-database)
   - [Select a Collection](#select-a-collection)
-  - [Changing `fetch()` on the Fly](#changing-fetch-on-the-fly)
   - [Collection Methods](#collection-methods)
     - [Return Type](#return-type)
+    - [Specifying Operation Names](#specifying-operation-names)
     - [Methods](#methods)
       - [findOne](#findone)
       - [find](#find)
@@ -130,7 +130,6 @@ const client = new MongoClient(options);
   - `options.dataSource` - `string` the `Data Source` for your Data API. On the Data API UI, this is the "Data Source" column, and usually is either a 1:1 mapping of your cluster name, or the default `mongodb-atlas` if you enabled Data API through the Atlas Admin UI.
   - `options.auth` - `AuthOptions` one of the authentication methods, either api key, email & password, or a custom JWT string. At this time, only [Credential Authentication](https://www.mongodb.com/docs/atlas/api/data-api/#credential-authentication) is supported.
   - `options.fetch?` - A custom `fetch` function conforming to the [native fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API). We recommend [cross-fetch](https://www.npmjs.com/package/cross-fetch), as it asserts a complaint `fetch()` interface and avoids you having to do `fetch: _fetch as typeof fetch` to satisfy the TypeScript compiler
-  - `options.headers?` - Additional [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) to include with the request. May also be a simple object of key/value pairs.
 
 ## Select a Database
 
@@ -148,15 +147,6 @@ const collection = db.collection<TSchema>(collectionName);
 
 - `collectionName` - `string` the name of the collection to connect to
 - `<TSchema>` - _generic_ A Type or Interface that describes the documents in this collection. Defaults to the generic MongoDB `Document` type
-
-## Changing `fetch()` on the Fly
-
-```ts
-const altDb = db.fetch(altFetch);
-const altCollection = db.collection<TSchema>(collectionName).fetch(altFetch);
-```
-
-- `altFetch` - An alternate `fetch` implementation that will be used for that point forward. Useful for adding or removing retry support on a per-call level, changing the authentication required, or other fetch middleware operations.
 
 ## Collection Methods
 
@@ -186,6 +176,14 @@ interface DataAPIResponse {
   data?: TSchema;
   error?: DataAPIError;
 }
+```
+
+### Specifying Operation Names
+
+To help with tracing and debugging, any Mongo Data API operation can be named by passing a string as the first parameter. This value is converted to the `x-realm-op-name` header and can be seen in the [Mongo Data API logs](https://www.mongodb.com/docs/atlas/api/data-api/#view-data-api-logs).
+
+```ts
+const { data, error } = await collection./*operation*/("operation name for tracing", filter, options);
 ```
 
 ### Methods

--- a/src/client.ts
+++ b/src/client.ts
@@ -261,14 +261,14 @@ export class Collection<TSchema = Document> {
    */
   async findOne(
     filter?: Filter<TSchema>,
-    options: { projection?: Document; sort?: Document } = {}
+    options?: { projection?: Document; sort?: Document }
   ): Promise<DataAPIResponse<Nullable<WithId<TSchema>>>> {
     const { data, error } = await this.callApi<{ document: WithId<TSchema> }>(
       "findOne",
       {
         filter,
-        projection: options.projection,
-        sort: options.sort,
+        projection: options?.projection,
+        sort: options?.sort,
       }
     );
 
@@ -360,7 +360,7 @@ export class Collection<TSchema = Document> {
   async updateOne(
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema> | Partial<TSchema>,
-    options: { upsert?: boolean } = {}
+    options?: { upsert?: boolean }
   ): Promise<
     DataAPIResponse<{
       matchedCount: number;
@@ -371,7 +371,7 @@ export class Collection<TSchema = Document> {
     return this.callApi("updateOne", {
       filter,
       update,
-      upsert: options.upsert,
+      upsert: options?.upsert,
     });
   }
 
@@ -390,7 +390,7 @@ export class Collection<TSchema = Document> {
   async updateMany(
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema>,
-    { upsert }: { upsert?: boolean } = {}
+    options?: { upsert?: boolean }
   ): Promise<
     DataAPIResponse<{
       matchedCount: number;
@@ -401,7 +401,7 @@ export class Collection<TSchema = Document> {
     return this.callApi("updateMany", {
       filter,
       update,
-      upsert,
+      upsert: options?.upsert,
     });
   }
 
@@ -420,7 +420,7 @@ export class Collection<TSchema = Document> {
   async replaceOne(
     filter: Filter<TSchema>,
     replacement: WithoutId<TSchema>,
-    options: { upsert?: boolean } = {}
+    options?: { upsert?: boolean }
   ): Promise<
     DataAPIResponse<{
       matchedCount: number;
@@ -431,7 +431,7 @@ export class Collection<TSchema = Document> {
     return this.callApi("replaceOne", {
       filter,
       replacement,
-      upsert: options.upsert,
+      upsert: options?.upsert,
     });
   }
 

--- a/src/responseTypes.ts
+++ b/src/responseTypes.ts
@@ -1,0 +1,91 @@
+import type { ObjectId } from "bson";
+import type { Sort, WithId, Document } from "mongodb";
+import { type MongoDataAPIError } from "./errors.js";
+
+/** Describes a typing that may be null */
+// eslint-disable-next-line @typescript-eslint/ban-types
+type Nullable<T> = T | null;
+
+/** A data API response object */
+export type DataAPIResponse<T> = { data?: T; error?: MongoDataAPIError };
+
+export type FindOneRequestOptions = { projection?: Document; sort?: Document };
+
+/** A data API response object */
+export type FindOneResponse<TSchema> = Promise<
+  DataAPIResponse<Nullable<WithId<TSchema>>>
+>;
+
+/** The MongoDB-specific options for this API method */
+export type FindRequestOptions = {
+  projection?: Document;
+  sort?: Sort;
+  limit?: number;
+  skip?: number;
+};
+
+/** A data API response object */
+export type FindResponse<TSchema> = Promise<
+  DataAPIResponse<Array<WithId<TSchema>>>
+>;
+
+/** A data API response object */
+export type InsertOneResponse = Promise<
+  DataAPIResponse<{ insertedId: ObjectId }>
+>;
+
+/** A data API response object */
+export type InsertManyResponse = Promise<
+  DataAPIResponse<{ insertedIds: string[] }>
+>;
+
+/** The MongoDB-specific options for this API method */
+export type UpdateOneRequestOptions = { upsert?: boolean };
+
+/** A data API response object */
+export type UpdateOneResponse = Promise<
+  DataAPIResponse<{
+    matchedCount: number;
+    modifiedCount: number;
+    upsertedId?: string;
+  }>
+>;
+
+/** The MongoDB-specific options for this API method */
+export type UpdateManyRequestOptions = { upsert?: boolean };
+
+/** A data API response object */
+export type UpdateManyResponse = Promise<
+  DataAPIResponse<{
+    matchedCount: number;
+    modifiedCount: number;
+    upsertedId?: string;
+  }>
+>;
+
+/** The MongoDB-specific options for this API method */
+export type ReplaceOneRequestOptions = { upsert?: boolean };
+
+/** A data API response object */
+export type ReplaceOneResponse = Promise<
+  DataAPIResponse<{
+    matchedCount: number;
+    modifiedCount: number;
+    upsertedId?: string;
+  }>
+>;
+
+/** A data API response object */
+export type DeleteOneResponse = Promise<
+  DataAPIResponse<{ deletedCount: number }>
+>;
+
+/** A data API response object */
+export type DeleteManyResponse = Promise<
+  DataAPIResponse<{ deletedCount: number }>
+>;
+
+/** A data API response object */
+export type AggregateResponse<TOutput = Document> = Promise<
+  DataAPIResponse<TOutput[]>
+>;

--- a/test/configure.spec.ts
+++ b/test/configure.spec.ts
@@ -3,8 +3,8 @@ import fetch from "cross-fetch";
 import { MongoClient } from "../src/client.js";
 import { BASE_URL } from "./mocks/handlers.js";
 
-test("requires a fetch interface", (t) => {
-  t.throws(() => {
+test("requires a valid fetch interface", async (t) => {
+  await t.throwsAsync(async () => {
     const c = new MongoClient({
       endpoint: BASE_URL,
       dataSource: "test-datasource",
@@ -12,6 +12,7 @@ test("requires a fetch interface", (t) => {
       // @ts-expect-error intentionally knocking out the fetch interface
       fetch: "not a fetch interface",
     });
+    await c.db("any").collection("any").find();
   });
 });
 


### PR DESCRIPTION
Previously, setting an operation name required a large song & dance to set a custom header which had no standardization; it was a major reason previous versions of the library introduced granular control of `fetch` and `headers`.

This change removes the fetch/header support in favor of a simpler polymorphic function.

`db().collection().find(filter, options)`

`db().collection().find(operationName, filter, options)`

If provided, the operation name sets the `x-realm-op-name` header.

Closes #6 